### PR TITLE
design/implement entities, apply JPA, integrate MariaDB

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -32,11 +32,11 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.mariadb.jdbc</groupId>-->
-<!--            <artifactId>mariadb-java-client</artifactId>-->
-<!--            <scope>runtime</scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/backend/src/main/java/com/dashdash/backend/BackendApplication.java
+++ b/backend/src/main/java/com/dashdash/backend/BackendApplication.java
@@ -2,9 +2,10 @@ package com.dashdash.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@EnableJpaAuditing
+@SpringBootApplication
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/dashdash/backend/application/model/BaseEntity.java
+++ b/backend/src/main/java/com/dashdash/backend/application/model/BaseEntity.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Getter
 @MappedSuperclass
@@ -16,9 +15,9 @@ import java.util.UUID;
 public class BaseEntity implements Serializable {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false)
-    private UUID id;
+    private Long id;
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/dashdash/backend/application/model/BaseEntity.java
+++ b/backend/src/main/java/com/dashdash/backend/application/model/BaseEntity.java
@@ -1,24 +1,23 @@
 package com.dashdash.backend.application.model;
 
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@Setter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity implements Serializable {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
     private UUID id;
 
     @CreatedDate

--- a/backend/src/main/java/com/dashdash/backend/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/controller/MenuController.java
@@ -1,8 +1,9 @@
 package com.dashdash.backend.menu.controller;
 
-import com.dashdash.backend.menu.model.Menu;
+import com.dashdash.backend.menu.model.MenuDto;
 import com.dashdash.backend.menu.service.MenuService;
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -18,8 +19,8 @@ public class MenuController {
     }
 
     @PostMapping
-    public ResponseEntity<Menu> saveMenu(@RequestBody Menu menu) {
-        Menu updatedMenu = menuService.save(menu);
+    public ResponseEntity<MenuDto> saveMenu(@RequestBody MenuDto menuDto) {
+        MenuDto updatedMenu = menuService.save(menuDto);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
@@ -27,8 +28,8 @@ public class MenuController {
     }
 
     @GetMapping("/{menuId}")
-    public ResponseEntity<Menu> getMenu(@PathVariable UUID menuId) {
-        Menu menu = menuService.getById(menuId);
+    public ResponseEntity<MenuDto> getMenu(@PathVariable UUID menuId) {
+        MenuDto menu = menuService.getById(menuId);
 
         return menu != null ?
                 ResponseEntity.status(HttpStatus.OK).body(menu)
@@ -37,8 +38,8 @@ public class MenuController {
 
 
     @PutMapping("/{menuId}")
-    public ResponseEntity<Menu> updateMenu(@PathVariable UUID menuId, @RequestBody Menu menu) {
-        Menu updatedMenu = menuService.updateById(menuId, menu);
+    public ResponseEntity<MenuDto> updateMenu(@PathVariable UUID menuId, @RequestBody MenuDto menuDto) {
+        MenuDto updatedMenu = menuService.updateById(menuId, menuDto);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -46,8 +47,8 @@ public class MenuController {
     }
 
     @DeleteMapping("/{menuId}")
-    public ResponseEntity<Menu> deleteMenu(@PathVariable UUID menuId) {
-        Menu menu = menuService.getById(menuId);
+    public ResponseEntity<MenuDto> deleteMenu(@PathVariable UUID menuId) {
+        MenuDto menu = menuService.getById(menuId);
         menuService.deleteById(menuId);
 
         return ResponseEntity

--- a/backend/src/main/java/com/dashdash/backend/menu/controller/MenuController.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/controller/MenuController.java
@@ -6,8 +6,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/menus")
 public class MenuController {
@@ -28,7 +26,7 @@ public class MenuController {
     }
 
     @GetMapping("/{menuId}")
-    public ResponseEntity<MenuDto> getMenu(@PathVariable UUID menuId) {
+    public ResponseEntity<MenuDto> getMenu(@PathVariable Long menuId) {
         MenuDto menu = menuService.getById(menuId);
 
         return menu != null ?
@@ -38,7 +36,7 @@ public class MenuController {
 
 
     @PutMapping("/{menuId}")
-    public ResponseEntity<MenuDto> updateMenu(@PathVariable UUID menuId, @RequestBody MenuDto menuDto) {
+    public ResponseEntity<MenuDto> updateMenu(@PathVariable Long menuId, @RequestBody MenuDto menuDto) {
         MenuDto updatedMenu = menuService.updateById(menuId, menuDto);
 
         return ResponseEntity
@@ -47,7 +45,7 @@ public class MenuController {
     }
 
     @DeleteMapping("/{menuId}")
-    public ResponseEntity<MenuDto> deleteMenu(@PathVariable UUID menuId) {
+    public ResponseEntity<MenuDto> deleteMenu(@PathVariable Long menuId) {
         MenuDto menu = menuService.getById(menuId);
         menuService.deleteById(menuId);
 

--- a/backend/src/main/java/com/dashdash/backend/menu/model/Menu.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/model/Menu.java
@@ -1,18 +1,40 @@
 package com.dashdash.backend.menu.model;
 
 import com.dashdash.backend.application.model.BaseEntity;
+import com.dashdash.backend.order.model.OrderDetail;
 import com.dashdash.backend.restaurant.model.Restaurant;
-import lombok.Builder;
-import lombok.Getter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.*;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
-@Builder(toBuilder = true)
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Menu extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
+
     private String name;
     private BigDecimal price;
     private String options;
     private byte[] image;
+
+    @OneToMany(mappedBy = "menu")
+    private List<OrderDetail> orderDetails;
+
+    @Builder(toBuilder = true)
+    public Menu(String name, BigDecimal price, String options, byte[] image) {
+        this.name = name;
+        this.price = price;
+        this.options = options;
+        this.image = image;
+    }
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/model/Menu.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/model/Menu.java
@@ -2,13 +2,13 @@ package com.dashdash.backend.menu.model;
 
 import com.dashdash.backend.application.model.BaseEntity;
 import com.dashdash.backend.restaurant.model.Restaurant;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 
 @Getter
-@Setter
+@Builder(toBuilder = true)
 public class Menu extends BaseEntity {
     private Restaurant restaurant;
     private String name;

--- a/backend/src/main/java/com/dashdash/backend/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/model/MenuDto.java
@@ -4,12 +4,11 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 @Getter
 @Builder(toBuilder = true)
 public class MenuDto {
-    private UUID id;
+    private Long id;
     private String name;
     private BigDecimal price;
     private String options;

--- a/backend/src/main/java/com/dashdash/backend/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/model/MenuDto.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 @Getter
 @Builder(toBuilder = true)
 public class MenuDto {
+    private UUID id;
     private String name;
     private BigDecimal price;
     private String options;

--- a/backend/src/main/java/com/dashdash/backend/menu/model/MenuDto.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/model/MenuDto.java
@@ -1,4 +1,15 @@
 package com.dashdash.backend.menu.model;
 
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder(toBuilder = true)
 public class MenuDto {
+    private String name;
+    private BigDecimal price;
+    private String options;
+    private byte[] image;
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepository.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepository.java
@@ -5,12 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Repository
-public interface MenuRepository extends JpaRepository<Menu, UUID> {
+public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Override
-    Optional<Menu> findById(UUID uuid);
+    Optional<Menu> findById(Long id);
 
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepository.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepository.java
@@ -1,17 +1,16 @@
 package com.dashdash.backend.menu.repository;
 
 import com.dashdash.backend.menu.model.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface MenuRepository {
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, UUID> {
 
-    Menu save(Menu menu);
+    @Override
+    Optional<Menu> findById(UUID uuid);
 
-    Menu findById(UUID id);
-
-    Menu updateById(UUID id, Menu menu);
-
-    void deleteById(UUID id);
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepositoryImpl.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepositoryImpl.java
@@ -4,19 +4,19 @@ package com.dashdash.backend.menu.repository;
 //@Repository
 public class MenuRepositoryImpl {
 //
-//    private Map<UUID, Menu> db = new HashMap<>();
+//    private Map<Long, Menu> db = new HashMap<>();
 //
 //    public Menu save(Menu menu) {
-//        menu.setId(UUID.randomUUID());
+//        menu.setId(Long.randomLong());
 //        db.put(menu.getId(), menu);
 //        return menu;
 //    }
 //
-//    public Menu findMenuById(UUID id) {
+//    public Menu findMenuById(Long id) {
 //        return db.get(id);
 //    }
 //
-//    public Menu updateById(UUID id, Menu updatedMenu) {
+//    public Menu updateById(Long id, Menu updatedMenu) {
 //        if (db.containsKey(id)) {
 //            db.put(id, updatedMenu);
 //            return updatedMenu;
@@ -25,7 +25,7 @@ public class MenuRepositoryImpl {
 //        }
 //    }
 //
-//    public void deleteById(UUID id) {
+//    public void deleteById(Long id) {
 //        db.remove(id);
 //    }
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepositoryImpl.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/repository/MenuRepositoryImpl.java
@@ -1,41 +1,31 @@
 package com.dashdash.backend.menu.repository;
 
-import com.dashdash.backend.menu.model.Menu;
-import org.springframework.stereotype.Repository;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-@Repository
-public class MenuRepositoryImpl implements MenuRepository {
-
-    private Map<UUID, Menu> db = new HashMap<>();
-
-    @Override
-    public Menu save(Menu menu) {
-        menu.setId(UUID.randomUUID());
-        db.put(menu.getId(), menu);
-        return menu;
-    }
-
-    @Override
-    public Menu findById(UUID id) {
-        return db.get(id);
-    }
-
-    @Override
-    public Menu updateById(UUID id, Menu updatedMenu) {
-        if (db.containsKey(id)) {
-            db.put(id, updatedMenu);
-            return updatedMenu;
-        } else {
-            return null;
-        }
-    }
-
-    @Override
-    public void deleteById(UUID id) {
-        db.remove(id);
-    }
+// TODO: Delete this class later
+//@Repository
+public class MenuRepositoryImpl {
+//
+//    private Map<UUID, Menu> db = new HashMap<>();
+//
+//    public Menu save(Menu menu) {
+//        menu.setId(UUID.randomUUID());
+//        db.put(menu.getId(), menu);
+//        return menu;
+//    }
+//
+//    public Menu findMenuById(UUID id) {
+//        return db.get(id);
+//    }
+//
+//    public Menu updateById(UUID id, Menu updatedMenu) {
+//        if (db.containsKey(id)) {
+//            db.put(id, updatedMenu);
+//            return updatedMenu;
+//        } else {
+//            return null;
+//        }
+//    }
+//
+//    public void deleteById(UUID id) {
+//        db.remove(id);
+//    }
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuService.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuService.java
@@ -16,6 +16,7 @@ public interface MenuService {
 
     default MenuDto entityToDto(Menu menu) {
         return MenuDto.builder()
+                .id(menu.getId())
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .options(menu.getOptions())

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuService.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuService.java
@@ -1,15 +1,34 @@
 package com.dashdash.backend.menu.service;
 
 import com.dashdash.backend.menu.model.Menu;
+import com.dashdash.backend.menu.model.MenuDto;
 
 import java.util.UUID;
 
 public interface MenuService {
-    Menu save(Menu menu);
+    MenuDto save(MenuDto menuDto);
 
-    Menu getById(UUID id);
+    MenuDto getById(UUID id);
 
-    Menu updateById(UUID id, Menu menu);
+    MenuDto updateById(UUID id, MenuDto menuDto);
 
     void deleteById(UUID id);
+
+    default MenuDto entityToDto(Menu menu) {
+        return MenuDto.builder()
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .options(menu.getOptions())
+                .image(menu.getImage())
+                .build();
+    }
+
+    default Menu dtoToEntity(MenuDto menuDto) {
+        return Menu.builder()
+                .name(menuDto.getName())
+                .price(menuDto.getPrice())
+                .options(menuDto.getOptions())
+                .image(menuDto.getImage())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuService.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuService.java
@@ -3,16 +3,14 @@ package com.dashdash.backend.menu.service;
 import com.dashdash.backend.menu.model.Menu;
 import com.dashdash.backend.menu.model.MenuDto;
 
-import java.util.UUID;
-
 public interface MenuService {
     MenuDto save(MenuDto menuDto);
 
-    MenuDto getById(UUID id);
+    MenuDto getById(Long id);
 
-    MenuDto updateById(UUID id, MenuDto menuDto);
+    MenuDto updateById(Long id, MenuDto menuDto);
 
-    void deleteById(UUID id);
+    void deleteById(Long id);
 
     default MenuDto entityToDto(Menu menu) {
         return MenuDto.builder()

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dashdash.backend.menu.service;
 
 import com.dashdash.backend.menu.model.Menu;
+import com.dashdash.backend.menu.model.MenuDto;
 import com.dashdash.backend.menu.repository.MenuRepository;
 import org.springframework.stereotype.Service;
 
@@ -16,25 +17,33 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
-    public Menu save(Menu menu) {
-        return menuRepository.save(menu);
+    public MenuDto save(MenuDto menuDto) {
+        Menu menu = dtoToEntity(menuDto);
+        Menu savedMenu = menuRepository.save(menu);
+
+        return entityToDto(savedMenu);
     }
 
     @Override
-    public Menu getById(UUID id) {
-        return menuRepository.findById(id);
+    public MenuDto getById(UUID id) {
+        Menu menu = menuRepository.findById(id);
+
+        return entityToDto(menu);
     }
 
     @Override
-    public Menu updateById(UUID id, Menu updatedMenu) {
-        Menu existingMenu = this.getById(id);
+    public MenuDto updateById(UUID id, MenuDto menuDto) {
+        Menu existingMenu = menuRepository.findById(id);
 
         if (existingMenu != null) {
-            existingMenu.setName(updatedMenu.getName());
-            existingMenu.setPrice(updatedMenu.getPrice());
-            existingMenu.setOptions(updatedMenu.getOptions());
+            Menu updatedMenu = existingMenu.toBuilder()
+                    .name(menuDto.getName())
+                    .price(menuDto.getPrice())
+                    .options(menuDto.getOptions())
+                    .image(menuDto.getImage())
+                    .build();
 
-            return menuRepository.updateById(existingMenu.getId(), existingMenu);
+            return entityToDto(menuRepository.updateById(existingMenu.getId(), updatedMenu));
         } else {
             return null;
         }

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
@@ -26,27 +26,35 @@ public class MenuServiceImpl implements MenuService {
 
     @Override
     public MenuDto getById(UUID id) {
-        Menu menu = menuRepository.findById(id);
+        Menu menu = menuRepository.findById(id).orElseThrow(() -> new RuntimeException("Menu not found!"));
 
         return entityToDto(menu);
     }
 
     @Override
     public MenuDto updateById(UUID id, MenuDto menuDto) {
-        Menu existingMenu = menuRepository.findById(id);
 
-        if (existingMenu != null) {
-            Menu updatedMenu = existingMenu.toBuilder()
-                    .name(menuDto.getName())
-                    .price(menuDto.getPrice())
-                    .options(menuDto.getOptions())
-                    .image(menuDto.getImage())
-                    .build();
+        Menu savedMenu = menuRepository.findById(id)
+                .map(menu -> {
+                    menu.setName(menuDto.getName());
+                    menu.setPrice(menuDto.getPrice());
+                    menu.setOptions(menuDto.getOptions());
+                    menu.setImage(menuDto.getImage());
+                    return menuRepository.save(menu);
+                })
+                .orElseThrow(() -> new RuntimeException("Menu not saved!"));
 
-            return entityToDto(menuRepository.updateById(existingMenu.getId(), updatedMenu));
-        } else {
-            return null;
-        }
+        return entityToDto(savedMenu);
+
+//            // This created new object, and trigger INSERT... instead of UPDATE...
+//            Menu updatedMenu = existingMenu.toBuilder()
+//                    .name(menuDto.getName())
+//                    .price(menuDto.getPrice())
+//                    .options(menuDto.getOptions())
+//                    .image(menuDto.getImage())
+//                    .build();
+//
+//            return entityToDto(menuRepository.save(menuFromDb));
     }
 
     @Override

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
@@ -43,16 +43,6 @@ public class MenuServiceImpl implements MenuService {
                 .orElseThrow(() -> new RuntimeException("Menu not saved!"));
 
         return entityToDto(savedMenu);
-
-//            // This created new object, and trigger INSERT... instead of UPDATE...
-//            Menu updatedMenu = existingMenu.toBuilder()
-//                    .name(menuDto.getName())
-//                    .price(menuDto.getPrice())
-//                    .options(menuDto.getOptions())
-//                    .image(menuDto.getImage())
-//                    .build();
-//
-//            return entityToDto(menuRepository.save(menuFromDb));
     }
 
     @Override

--- a/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
+++ b/backend/src/main/java/com/dashdash/backend/menu/service/MenuServiceImpl.java
@@ -5,8 +5,6 @@ import com.dashdash.backend.menu.model.MenuDto;
 import com.dashdash.backend.menu.repository.MenuRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.UUID;
-
 @Service
 public class MenuServiceImpl implements MenuService {
 
@@ -25,14 +23,14 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
-    public MenuDto getById(UUID id) {
+    public MenuDto getById(Long id) {
         Menu menu = menuRepository.findById(id).orElseThrow(() -> new RuntimeException("Menu not found!"));
 
         return entityToDto(menu);
     }
 
     @Override
-    public MenuDto updateById(UUID id, MenuDto menuDto) {
+    public MenuDto updateById(Long id, MenuDto menuDto) {
 
         Menu savedMenu = menuRepository.findById(id)
                 .map(menu -> {
@@ -58,7 +56,7 @@ public class MenuServiceImpl implements MenuService {
     }
 
     @Override
-    public void deleteById(UUID id) {
+    public void deleteById(Long id) {
         menuRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/com/dashdash/backend/order/model/Order.java
+++ b/backend/src/main/java/com/dashdash/backend/order/model/Order.java
@@ -1,0 +1,29 @@
+package com.dashdash.backend.order.model;
+
+import com.dashdash.backend.application.model.BaseEntity;
+import com.dashdash.backend.restaurant.model.Restaurant;
+import com.dashdash.backend.user.model.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Entity
+public class Order extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @OneToMany(mappedBy = "order")
+    private List<OrderDetail> orderDetails;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+}

--- a/backend/src/main/java/com/dashdash/backend/order/model/OrderDetail.java
+++ b/backend/src/main/java/com/dashdash/backend/order/model/OrderDetail.java
@@ -1,0 +1,28 @@
+package com.dashdash.backend.order.model;
+
+import com.dashdash.backend.application.model.BaseEntity;
+import com.dashdash.backend.menu.model.Menu;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+public class OrderDetail extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    private int quantity;
+
+    private BigDecimal totalAmount;
+
+}

--- a/backend/src/main/java/com/dashdash/backend/order/model/OrderStatus.java
+++ b/backend/src/main/java/com/dashdash/backend/order/model/OrderStatus.java
@@ -1,0 +1,9 @@
+package com.dashdash.backend.order.model;
+
+public enum OrderStatus {
+    CREATED,
+    PROCESSING,
+    PENDING,
+    COMPLETED,
+    CANCELED
+}

--- a/backend/src/main/java/com/dashdash/backend/restaurant/model/Restaurant.java
+++ b/backend/src/main/java/com/dashdash/backend/restaurant/model/Restaurant.java
@@ -2,13 +2,31 @@ package com.dashdash.backend.restaurant.model;
 
 import com.dashdash.backend.application.model.BaseEntity;
 import com.dashdash.backend.menu.model.Menu;
+import com.dashdash.backend.order.model.Order;
+import com.dashdash.backend.user.model.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.util.List;
 
 @Getter
-@Setter
+@Entity
 public class Restaurant extends BaseEntity {
+
+    private String name;
+
+    @ManyToOne
+    private User owner;
+
+    private String address;
+    private String phone;
+
+    @OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL)
+    private List<Order> orders;
+
+    @OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL)
     private List<Menu> menus;
 }

--- a/backend/src/main/java/com/dashdash/backend/user/model/User.java
+++ b/backend/src/main/java/com/dashdash/backend/user/model/User.java
@@ -1,0 +1,30 @@
+package com.dashdash.backend.user.model;
+
+import com.dashdash.backend.application.model.BaseEntity;
+import com.dashdash.backend.order.model.Order;
+import com.dashdash.backend.restaurant.model.Restaurant;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Entity
+public class User extends BaseEntity {
+
+    private String username;
+    private String firstname;
+    private String lastname;
+    private String email;
+    private String address;
+    private String role;
+
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
+    private List<Restaurant> restaurants;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Order> orders;
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,10 +1,15 @@
+# DB Config
 spring.datasource.url=jdbc:mariadb://localhost:3306/dashdashdb
 spring.datasource.username=admin
 spring.datasource.password=admin123
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=update
+# JPA
 spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
 # Allow using MariaDB reserved keyword, e.g.`order`:
 spring.jpa.properties.hibernate.globally_quoted_identifiers=true
-#spring.sql.init.data-locations=sql/mariadb-data.sql
+# SQL Script
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
+spring.sql.init.data-locations=classpath:/sql/data.sql

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,10 @@
-
+spring.datasource.url=jdbc:mariadb://localhost:3306/dashdashdb
+spring.datasource.username=admin
+spring.datasource.password=admin123
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+# Allow using MariaDB reserved keyword, e.g.`order`:
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true
+#spring.sql.init.data-locations=sql/mariadb-data.sql

--- a/backend/src/main/resources/sql/data.sql
+++ b/backend/src/main/resources/sql/data.sql
@@ -1,0 +1,187 @@
+use dashdashdb;
+
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (1, 'gmattersey0', 'Gerik', 'Mattersey', null, '593 Sunnyside Center', 'gmattersey0@vimeo.com',
+        '2023-10-13 01:31:13', '2023-11-04 11:16:38');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (2, 'asindell1', 'Afton', 'Sindell', null, '6710 Lerdahl Alley', 'asindell1@linkedin.com', '2023-10-02 01:11:28',
+        '2023-11-08 23:00:28');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (3, 'foscroft2', 'Fianna', 'Oscroft', null, '4 Florence Street', 'foscroft2@nationalgeographic.com',
+        '2023-10-04 23:58:20', '2023-11-16 04:13:19');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (4, 'sscotsbrook3', 'Stephie', 'Scotsbrook', null, '69561 Dayton Center', 'sscotsbrook3@trellian.com',
+        '2023-10-21 15:39:28', '2023-11-03 20:18:21');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (5, 'cfiennes4', 'Cosimo', 'Fiennes', null, '3 Porter Center', 'cfiennes4@weebly.com', '2023-10-14 06:37:58',
+        '2023-11-06 00:13:27');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (6, 'dkincla5', 'Stévina', 'Kincla', null, '017 Beilfuss Crossing', 'akincla5@stumbleupon.com',
+        '2023-10-08 13:58:30', '2023-11-11 18:21:41');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (7, 'wbartalucci6', 'Kuí', 'Bartalucci', null, '21 Toban Street', 'bbartalucci6@washingtonpost.com',
+        '2023-10-12 04:52:28', '2023-11-09 11:11:04');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (8, 'wwhitehorn7', 'Fèi', 'Whitehorn', null, '4800 Columbus Plaza', 'ywhitehorn7@clickbank.net',
+        '2023-10-12 05:08:37', '2023-11-13 06:32:38');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (9, 'rrenneke8', 'Lauréna', 'Renneke', null, '4 Glendale Court', 'mrenneke8@mayoclinic.com',
+        '2023-10-16 13:07:10', '2023-11-12 04:45:59');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (10, 'sparkins9', 'Anaël', 'Parkins', null, '69381 Meadow Vale Terrace', 'dparkins9@cdc.gov',
+        '2023-10-17 04:10:09', '2023-11-03 06:49:05');
+
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (1, 'Bankwell Financial Group, Inc.', '+62 (525) 217-0773', '14127 Gale Plaza', 6, '2023-10-22 14:34:19',
+        '2023-11-16 09:22:01');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (2, 'Tejon Ranch Co', '+351 (530) 727-4332', '5989 Northridge Lane', 6, '2023-10-24 12:27:02',
+        '2023-11-03 20:01:03');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (3, 'Vocera Communications, Inc.', '+7 (413) 389-0275', '2865 Esch Hill', 5, '2023-10-21 07:26:57',
+        '2023-11-16 17:06:44');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (4, 'Salem Media Group, Inc.', '+86 (834) 126-9211', '2 Susan Park', 8, '2023-10-24 12:56:26',
+        '2023-11-09 05:53:36');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (5, 'Capital One Financial Corporation', '+55 (448) 750-7374', '9 Lukken Point', 8, '2023-10-13 17:13:45',
+        '2023-11-04 03:55:29');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (6, 'ECA Marcellus Trust I', '+7 (752) 794-3769', '1 Bayside Parkway', 8, '2023-10-12 19:14:54',
+        '2023-11-01 19:07:23');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (7, 'Total System Services, Inc.', '+57 (787) 889-7440', '619 Schmedeman Parkway', 8, '2023-10-10 14:39:36',
+        '2023-11-01 12:27:31');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (8, 'Matson, Inc.', '+7 (902) 177-6821', '749 Forest Dale Parkway', 8, '2023-10-28 07:35:43',
+        '2023-11-15 05:25:32');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (9, 'Art''s-Way Manufacturing Co., Inc.', '+62 (900) 483-2945', '20 6th Point', 8, '2023-10-24 10:01:29',
+        '2023-11-11 12:06:56');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (10, 'DelMar Pharmaceuticals, Inc.', '+62 (824) 950-1016', '0725 Monica Trail', 7, '2023-10-17 04:36:08',
+        '2023-11-12 13:59:19');
+
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (1, 'Doilies - 7, Paper', 23.97, null, null, 1, '2023-10-05 04:50:49', '2023-11-08 04:14:51');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (2, 'Pork - Kidney', 11.34, null, null, 5, '2023-10-26 18:08:39', '2023-11-03 10:41:44');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (3, 'Container - Clear 32 Oz', 29.34, null, null, 5, '2023-10-28 03:23:14', '2023-11-15 03:59:12');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (4, 'Yucca', 15.11, null, null, 5, '2023-10-10 10:38:02', '2023-11-08 05:29:55');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (5, 'Asparagus - White, Fresh', 19.52, null, null, 1, '2023-10-20 19:38:50', '2023-11-16 05:13:42');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (6, 'Okra', 14.58, null, null, 3, '2023-10-10 16:14:19', '2023-11-10 03:03:41');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (7, 'Chocolate - White', 23.87, null, null, 5, '2023-10-17 22:25:45', '2023-11-15 16:41:26');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (8, 'Coffee - Almond Amaretto', 12.65, null, null, 3, '2023-10-06 10:27:52', '2023-11-13 12:29:20');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (9, 'Nantuket Peach Orange', 17.83, null, null, 5, '2023-10-30 17:50:28', '2023-11-15 19:34:49');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (10, 'Chilli Paste, Ginger Garlic', 8.49, null, null, 2, '2023-10-03 16:44:22', '2023-11-10 23:51:04');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (11, 'Olives - Kalamata', 7.47, null, null, 5, '2023-10-06 19:28:58', '2023-11-13 14:15:20');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (12, 'Muffin Hinge Container 6', 26.66, null, null, 1, '2023-10-30 17:11:15', '2023-11-03 14:57:09');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (13, 'Spice - Pepper Portions', 24.81, null, null, 1, '2023-10-26 21:00:46', '2023-11-10 23:50:46');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (14, 'Petite Baguette', 29.98, null, null, 3, '2023-10-09 20:11:12', '2023-11-16 10:48:57');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (15, 'Crab - Dungeness, Whole, live', 24.65, null, null, 1, '2023-10-15 05:51:27', '2023-11-03 06:24:05');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (16, 'Bread - Dark Rye', 27.61, null, null, 4, '2023-10-07 00:50:47', '2023-11-04 12:59:14');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (17, 'Compound - Orange', 19.16, null, null, 3, '2023-10-01 01:42:00', '2023-11-13 21:25:37');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (18, 'Macaroons - Homestyle Two Bit', 12.6, null, null, 4, '2023-10-29 22:31:32', '2023-11-02 09:35:51');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (19, 'Curry Powder', 15.99, null, null, 3, '2023-10-25 17:30:54', '2023-11-08 22:07:22');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (20, 'Oil - Shortening,liqud, Fry', 27.34, null, null, 3, '2023-10-30 06:56:35', '2023-11-08 09:37:32');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (21, 'Bread - Bagels, Mini', 28.92, null, null, 1, '2023-10-26 07:43:45', '2023-11-02 15:17:09');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (22, 'Plate Pie Foil', 25.23, null, null, 1, '2023-10-09 19:24:56', '2023-11-04 01:38:08');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (23, 'Wine - Ej Gallo Sonoma', 10.12, null, null, 3, '2023-10-06 20:51:06', '2023-11-13 22:30:41');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (24, 'Veal - Brisket, Provimi, Bone - In', 17.76, null, null, 2, '2023-10-17 22:23:56', '2023-11-08 12:27:39');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (25, 'Tamarind Paste', 28.09, null, null, 5, '2023-10-13 01:00:42', '2023-11-02 09:04:26');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (26, 'Country Roll', 18.39, null, null, 4, '2023-10-12 07:09:44', '2023-11-02 13:23:38');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (27, 'Beef - Ground Lean Fresh', 15.69, null, null, 3, '2023-10-02 16:55:39', '2023-11-01 17:04:18');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (28, 'Chocolate - Compound Coating', 25.26, null, null, 3, '2023-10-10 00:18:20', '2023-11-15 12:22:15');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (29, 'Container - Foam Dixie 12 Oz', 5.75, null, null, 5, '2023-10-18 17:24:01', '2023-11-12 14:04:11');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (30, 'Beef Ground Medium', 25.65, null, null, 4, '2023-10-18 19:59:40', '2023-11-03 06:25:09');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (1, 1, 1, 'PROCESSING', '2023-10-28 13:49:26', '2023-11-07 22:17:51');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (2, 1, 2, 'COMPLETED', '2023-10-07 04:59:56', '2023-11-04 00:54:20');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (3, 1, 3, 'PROCESSING', '2023-10-17 11:43:12', '2023-11-06 05:07:36');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (4, 1, 4, 'CREATED', '2023-10-07 15:45:05', '2023-11-12 14:49:14');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (5, 1, 5, 'CANCELED', '2023-10-04 07:38:03', '2023-11-03 05:54:01');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (6, 2, 1, 'PROCESSING', '2023-10-13 00:11:08', '2023-11-14 04:38:54');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (7, 2, 1, 'PROCESSING', '2023-10-08 14:35:46', '2023-11-13 04:10:39');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (8, 2, 2, 'CANCELED', '2023-10-14 06:40:05', '2023-11-01 18:38:55');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (9, 3, 3, 'PENDING', '2023-10-06 18:38:16', '2023-11-01 03:23:57');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (10, 4, 4, 'PENDING', '2023-10-23 18:48:48', '2023-11-09 02:38:51');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (1, 1, 1, 2, '2023-10-05 14:00:00', '2023-11-01 14:00:00'),
+       (2, 1, 5, 1, '2023-10-05 14:01:00', '2023-11-01 14:01:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (3, 2, 2, 3, '2023-10-06 14:02:00', '2023-11-02 14:02:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (4, 3, 6, 2, '2023-10-07 14:03:00', '2023-11-03 14:03:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (5, 4, 11, 1, '2023-10-08 14:04:00', '2023-11-04 14:04:00'),
+       (6, 4, 12, 1, '2023-10-08 14:05:00', '2023-11-04 14:05:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (7, 6, 1, 1, '2023-10-09 14:06:00', '2023-11-05 14:06:00'),
+       (8, 6, 5, 2, '2023-10-09 14:07:00', '2023-11-05 14:07:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (9, 7, 7, 1, '2023-10-10 14:08:00', '2023-11-06 14:08:00'),
+       (10, 7, 8, 1, '2023-10-10 14:09:00', '2023-11-06 14:09:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (11, 9, 15, 1, '2023-10-11 14:10:00', '2023-11-07 14:10:00'),
+       (12, 9, 17, 2, '2023-10-11 14:11:00', '2023-11-07 14:11:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (13, 10, 24, 1, '2023-10-12 14:12:00', '2023-11-08 14:12:00'),
+       (14, 10, 25, 2, '2023-10-12 14:13:00', '2023-11-08 14:13:00');
+
+UPDATE order_detail
+SET total_amount = quantity * (SELECT price FROM menu WHERE menu.id = order_detail.menu_id);

--- a/backend/src/test/java/menu/controller/MenuControllerTest.java
+++ b/backend/src/test/java/menu/controller/MenuControllerTest.java
@@ -1,0 +1,99 @@
+package menu.controller;
+
+import com.dashdash.backend.menu.controller.MenuController;
+import com.dashdash.backend.menu.model.MenuDto;
+import com.dashdash.backend.menu.service.MenuService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+public class MenuControllerTest {
+
+    @Mock
+    private MenuService menuService;
+
+    @InjectMocks
+    private MenuController menuController;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void createMenu() {
+        MenuDto menuDto = createMenuDto();
+        when(menuService.save(any(MenuDto.class))).thenReturn(menuDto);
+
+        ResponseEntity<MenuDto> response = menuController.saveMenu(menuDto);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(menuDto, response.getBody());
+    }
+
+    @Test
+    public void fetchMenuById() {
+        MenuDto menuDto = createMenuDto();
+        when(menuService.getById(anyLong())).thenReturn(menuDto);
+
+        ResponseEntity<MenuDto> response = menuController.getMenu(1L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(menuDto, response.getBody());
+    }
+
+    @Test
+    public void fetchMenuByIdWithNotFoundException() {
+        when(menuService.getById(anyLong())).thenReturn(null);
+
+        ResponseEntity<MenuDto> response = menuController.getMenu(1L);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(null, response.getBody());
+    }
+
+    @Test
+    public void updateMenu() {
+        MenuDto menuDto = createMenuDto();
+        when(menuService.updateById(anyLong(), any(MenuDto.class))).thenReturn(menuDto);
+
+        ResponseEntity<MenuDto> response = menuController.updateMenu(1L, menuDto);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(menuDto, response.getBody());
+    }
+
+    @Test
+    public void deleteMenuById() {
+        MenuDto menuDto = createMenuDto();
+        when(menuService.getById(anyLong())).thenReturn(menuDto);
+
+        ResponseEntity<MenuDto> response = menuController.deleteMenu(1L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(menuDto, response.getBody());
+
+        verify(menuService, times(1)).deleteById(1L);
+    }
+
+    private MenuDto createMenuDto() {
+        return MenuDto.builder()
+                .id(1L)
+                .name("Test Menu")
+                .price(new BigDecimal("10.00"))
+                .options("Option 1, Option 2")
+                .image(new byte[]{1, 2, 3, 4})
+                .build();
+    }
+}

--- a/backend/src/test/java/menu/service/MenuServiceImplTest.java
+++ b/backend/src/test/java/menu/service/MenuServiceImplTest.java
@@ -1,0 +1,112 @@
+package menu.service;
+
+import com.dashdash.backend.menu.model.Menu;
+import com.dashdash.backend.menu.model.MenuDto;
+import com.dashdash.backend.menu.repository.MenuRepository;
+import com.dashdash.backend.menu.service.MenuServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+public class MenuServiceImplTest {
+
+    @InjectMocks
+    private MenuServiceImpl menuService;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testSave() {
+        MenuDto menuDto = createMenuDto();
+        Menu menu = createMenu();
+        when(menuRepository.save(any(Menu.class))).thenReturn(menu);
+
+        MenuDto savedMenuDto = menuService.save(menuDto);
+
+        assertEquals(menuDto.getName(), savedMenuDto.getName());
+        assertEquals(menuDto.getPrice(), savedMenuDto.getPrice());
+    }
+
+    @Test
+    void testGetById() {
+        Menu menu = createMenu();
+        when(menuRepository.findById(anyLong())).thenReturn(Optional.of(menu));
+
+        MenuDto menuDto = menuService.getById(1L);
+
+        assertEquals(menu.getName(), menuDto.getName());
+        assertEquals(menu.getPrice(), menuDto.getPrice());
+    }
+
+    @Test
+    void testUpdateById() {
+        MenuDto menuDto = createMenuDto();
+        Menu menu = createMenu();
+        when(menuRepository.findById(anyLong())).thenReturn(Optional.of(menu));
+        when(menuRepository.save(any(Menu.class))).thenReturn(menu);
+
+        MenuDto updatedMenuDto = menuService.updateById(1L, menuDto);
+
+        assertEquals(menuDto.getName(), updatedMenuDto.getName());
+        assertEquals(menuDto.getPrice(), updatedMenuDto.getPrice());
+    }
+
+    @Test
+    void testDeleteById() {
+        menuService.deleteById(101L);
+
+        verify(menuRepository, times(1)).deleteById(101L);
+    }
+
+    @Test
+    void testGetByIdWhenMenuNotExist() {
+        when(menuRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> menuService.getById(101L));
+    }
+
+    @Test
+    void testUpdateByIdWhenMenuNotExist() {
+        MenuDto menuDto = createMenuDto();
+
+        when(menuRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> menuService.updateById(101L, menuDto));
+    }
+
+    private MenuDto createMenuDto() {
+        return MenuDto.builder()
+                .id(1L)
+                .name("Test Menu")
+                .price(new BigDecimal("10.00"))
+                .options("Option 1, Option 2")
+                .image(new byte[]{1, 2, 3, 4})
+                .build();
+    }
+
+    private Menu createMenu() {
+        return Menu.builder()
+                .name("Test Menu")
+                .price(new BigDecimal("10.00"))
+                .options("Option 1, Option 2")
+                .image(new byte[]{1, 2, 3, 4})
+                .build();
+    }
+}

--- a/backend/src/test/resources/sql/data-test.sql
+++ b/backend/src/test/resources/sql/data-test.sql
@@ -1,0 +1,187 @@
+use dashdashdb;
+
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (1, 'gmattersey0', 'Gerik', 'Mattersey', null, '593 Sunnyside Center', 'gmattersey0@vimeo.com',
+        '2023-10-13 01:31:13', '2023-11-04 11:16:38');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (2, 'asindell1', 'Afton', 'Sindell', null, '6710 Lerdahl Alley', 'asindell1@linkedin.com', '2023-10-02 01:11:28',
+        '2023-11-08 23:00:28');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (3, 'foscroft2', 'Fianna', 'Oscroft', null, '4 Florence Street', 'foscroft2@nationalgeographic.com',
+        '2023-10-04 23:58:20', '2023-11-16 04:13:19');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (4, 'sscotsbrook3', 'Stephie', 'Scotsbrook', null, '69561 Dayton Center', 'sscotsbrook3@trellian.com',
+        '2023-10-21 15:39:28', '2023-11-03 20:18:21');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (5, 'cfiennes4', 'Cosimo', 'Fiennes', null, '3 Porter Center', 'cfiennes4@weebly.com', '2023-10-14 06:37:58',
+        '2023-11-06 00:13:27');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (6, 'dkincla5', 'Stévina', 'Kincla', null, '017 Beilfuss Crossing', 'akincla5@stumbleupon.com',
+        '2023-10-08 13:58:30', '2023-11-11 18:21:41');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (7, 'wbartalucci6', 'Kuí', 'Bartalucci', null, '21 Toban Street', 'bbartalucci6@washingtonpost.com',
+        '2023-10-12 04:52:28', '2023-11-09 11:11:04');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (8, 'wwhitehorn7', 'Fèi', 'Whitehorn', null, '4800 Columbus Plaza', 'ywhitehorn7@clickbank.net',
+        '2023-10-12 05:08:37', '2023-11-13 06:32:38');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (9, 'rrenneke8', 'Lauréna', 'Renneke', null, '4 Glendale Court', 'mrenneke8@mayoclinic.com',
+        '2023-10-16 13:07:10', '2023-11-12 04:45:59');
+insert into user (id, username, firstname, lastname, role, address, email, created_at, updated_at)
+values (10, 'sparkins9', 'Anaël', 'Parkins', null, '69381 Meadow Vale Terrace', 'dparkins9@cdc.gov',
+        '2023-10-17 04:10:09', '2023-11-03 06:49:05');
+
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (1, 'Bankwell Financial Group, Inc.', '+62 (525) 217-0773', '14127 Gale Plaza', 6, '2023-10-22 14:34:19',
+        '2023-11-16 09:22:01');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (2, 'Tejon Ranch Co', '+351 (530) 727-4332', '5989 Northridge Lane', 6, '2023-10-24 12:27:02',
+        '2023-11-03 20:01:03');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (3, 'Vocera Communications, Inc.', '+7 (413) 389-0275', '2865 Esch Hill', 5, '2023-10-21 07:26:57',
+        '2023-11-16 17:06:44');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (4, 'Salem Media Group, Inc.', '+86 (834) 126-9211', '2 Susan Park', 8, '2023-10-24 12:56:26',
+        '2023-11-09 05:53:36');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (5, 'Capital One Financial Corporation', '+55 (448) 750-7374', '9 Lukken Point', 8, '2023-10-13 17:13:45',
+        '2023-11-04 03:55:29');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (6, 'ECA Marcellus Trust I', '+7 (752) 794-3769', '1 Bayside Parkway', 8, '2023-10-12 19:14:54',
+        '2023-11-01 19:07:23');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (7, 'Total System Services, Inc.', '+57 (787) 889-7440', '619 Schmedeman Parkway', 8, '2023-10-10 14:39:36',
+        '2023-11-01 12:27:31');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (8, 'Matson, Inc.', '+7 (902) 177-6821', '749 Forest Dale Parkway', 8, '2023-10-28 07:35:43',
+        '2023-11-15 05:25:32');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (9, 'Art''s-Way Manufacturing Co., Inc.', '+62 (900) 483-2945', '20 6th Point', 8, '2023-10-24 10:01:29',
+        '2023-11-11 12:06:56');
+insert into restaurant (id, name, phone, address, owner_id, created_at, updated_at)
+values (10, 'DelMar Pharmaceuticals, Inc.', '+62 (824) 950-1016', '0725 Monica Trail', 7, '2023-10-17 04:36:08',
+        '2023-11-12 13:59:19');
+
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (1, 'Doilies - 7, Paper', 23.97, null, null, 1, '2023-10-05 04:50:49', '2023-11-08 04:14:51');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (2, 'Pork - Kidney', 11.34, null, null, 5, '2023-10-26 18:08:39', '2023-11-03 10:41:44');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (3, 'Container - Clear 32 Oz', 29.34, null, null, 5, '2023-10-28 03:23:14', '2023-11-15 03:59:12');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (4, 'Yucca', 15.11, null, null, 5, '2023-10-10 10:38:02', '2023-11-08 05:29:55');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (5, 'Asparagus - White, Fresh', 19.52, null, null, 1, '2023-10-20 19:38:50', '2023-11-16 05:13:42');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (6, 'Okra', 14.58, null, null, 3, '2023-10-10 16:14:19', '2023-11-10 03:03:41');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (7, 'Chocolate - White', 23.87, null, null, 5, '2023-10-17 22:25:45', '2023-11-15 16:41:26');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (8, 'Coffee - Almond Amaretto', 12.65, null, null, 3, '2023-10-06 10:27:52', '2023-11-13 12:29:20');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (9, 'Nantuket Peach Orange', 17.83, null, null, 5, '2023-10-30 17:50:28', '2023-11-15 19:34:49');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (10, 'Chilli Paste, Ginger Garlic', 8.49, null, null, 2, '2023-10-03 16:44:22', '2023-11-10 23:51:04');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (11, 'Olives - Kalamata', 7.47, null, null, 5, '2023-10-06 19:28:58', '2023-11-13 14:15:20');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (12, 'Muffin Hinge Container 6', 26.66, null, null, 1, '2023-10-30 17:11:15', '2023-11-03 14:57:09');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (13, 'Spice - Pepper Portions', 24.81, null, null, 1, '2023-10-26 21:00:46', '2023-11-10 23:50:46');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (14, 'Petite Baguette', 29.98, null, null, 3, '2023-10-09 20:11:12', '2023-11-16 10:48:57');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (15, 'Crab - Dungeness, Whole, live', 24.65, null, null, 1, '2023-10-15 05:51:27', '2023-11-03 06:24:05');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (16, 'Bread - Dark Rye', 27.61, null, null, 4, '2023-10-07 00:50:47', '2023-11-04 12:59:14');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (17, 'Compound - Orange', 19.16, null, null, 3, '2023-10-01 01:42:00', '2023-11-13 21:25:37');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (18, 'Macaroons - Homestyle Two Bit', 12.6, null, null, 4, '2023-10-29 22:31:32', '2023-11-02 09:35:51');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (19, 'Curry Powder', 15.99, null, null, 3, '2023-10-25 17:30:54', '2023-11-08 22:07:22');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (20, 'Oil - Shortening,liqud, Fry', 27.34, null, null, 3, '2023-10-30 06:56:35', '2023-11-08 09:37:32');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (21, 'Bread - Bagels, Mini', 28.92, null, null, 1, '2023-10-26 07:43:45', '2023-11-02 15:17:09');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (22, 'Plate Pie Foil', 25.23, null, null, 1, '2023-10-09 19:24:56', '2023-11-04 01:38:08');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (23, 'Wine - Ej Gallo Sonoma', 10.12, null, null, 3, '2023-10-06 20:51:06', '2023-11-13 22:30:41');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (24, 'Veal - Brisket, Provimi, Bone - In', 17.76, null, null, 2, '2023-10-17 22:23:56', '2023-11-08 12:27:39');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (25, 'Tamarind Paste', 28.09, null, null, 5, '2023-10-13 01:00:42', '2023-11-02 09:04:26');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (26, 'Country Roll', 18.39, null, null, 4, '2023-10-12 07:09:44', '2023-11-02 13:23:38');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (27, 'Beef - Ground Lean Fresh', 15.69, null, null, 3, '2023-10-02 16:55:39', '2023-11-01 17:04:18');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (28, 'Chocolate - Compound Coating', 25.26, null, null, 3, '2023-10-10 00:18:20', '2023-11-15 12:22:15');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (29, 'Container - Foam Dixie 12 Oz', 5.75, null, null, 5, '2023-10-18 17:24:01', '2023-11-12 14:04:11');
+insert into menu (id, name, price, options, image, restaurant_id, created_at, updated_at)
+values (30, 'Beef Ground Medium', 25.65, null, null, 4, '2023-10-18 19:59:40', '2023-11-03 06:25:09');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (1, 1, 1, 'PROCESSING', '2023-10-28 13:49:26', '2023-11-07 22:17:51');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (2, 1, 2, 'COMPLETED', '2023-10-07 04:59:56', '2023-11-04 00:54:20');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (3, 1, 3, 'PROCESSING', '2023-10-17 11:43:12', '2023-11-06 05:07:36');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (4, 1, 4, 'CREATED', '2023-10-07 15:45:05', '2023-11-12 14:49:14');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (5, 1, 5, 'CANCELED', '2023-10-04 07:38:03', '2023-11-03 05:54:01');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (6, 2, 1, 'PROCESSING', '2023-10-13 00:11:08', '2023-11-14 04:38:54');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (7, 2, 1, 'PROCESSING', '2023-10-08 14:35:46', '2023-11-13 04:10:39');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (8, 2, 2, 'CANCELED', '2023-10-14 06:40:05', '2023-11-01 18:38:55');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (9, 3, 3, 'PENDING', '2023-10-06 18:38:16', '2023-11-01 03:23:57');
+
+INSERT INTO `order` (id, user_id, restaurant_id, status, created_at, updated_at)
+VALUES (10, 4, 4, 'PENDING', '2023-10-23 18:48:48', '2023-11-09 02:38:51');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (1, 1, 1, 2, '2023-10-05 14:00:00', '2023-11-01 14:00:00'),
+       (2, 1, 5, 1, '2023-10-05 14:01:00', '2023-11-01 14:01:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (3, 2, 2, 3, '2023-10-06 14:02:00', '2023-11-02 14:02:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (4, 3, 6, 2, '2023-10-07 14:03:00', '2023-11-03 14:03:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (5, 4, 11, 1, '2023-10-08 14:04:00', '2023-11-04 14:04:00'),
+       (6, 4, 12, 1, '2023-10-08 14:05:00', '2023-11-04 14:05:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (7, 6, 1, 1, '2023-10-09 14:06:00', '2023-11-05 14:06:00'),
+       (8, 6, 5, 2, '2023-10-09 14:07:00', '2023-11-05 14:07:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (9, 7, 7, 1, '2023-10-10 14:08:00', '2023-11-06 14:08:00'),
+       (10, 7, 8, 1, '2023-10-10 14:09:00', '2023-11-06 14:09:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (11, 9, 15, 1, '2023-10-11 14:10:00', '2023-11-07 14:10:00'),
+       (12, 9, 17, 2, '2023-10-11 14:11:00', '2023-11-07 14:11:00');
+
+INSERT INTO order_detail (id, order_id, menu_id, quantity, created_at, updated_at)
+VALUES (13, 10, 24, 1, '2023-10-12 14:12:00', '2023-11-08 14:12:00'),
+       (14, 10, 25, 2, '2023-10-12 14:13:00', '2023-11-08 14:13:00');
+
+UPDATE order_detail
+SET total_amount = quantity * (SELECT price FROM menu WHERE menu.id = order_detail.menu_id);


### PR DESCRIPTION
## Features

- [x] Added necessary database entities for a delivery application (User, Restaurant, Menu, Order, OrderDetail).
- [x] Used `@MappedSuperclass` to handle common fields (id, createdAt, updatedAt) among entities through the **BaseEntity**.
- [x] Added default methods `entityToDto` and `dtoToEntity` in the **MenuService** for conversion between DTO and Entity.
- [x] Changed the request/response handling object in the **Menu Controller** from entity to DTO.
- [x] Added application properties for MariaDB connection.
- [x] Added **data.sql** for initial database data creation.
- [x] Changed the primary key type of entities from UUID to Long for ease of development and testing.
- [x] Added unit tests for MenuController and MenuService.

## Issues and Solutions

**Issue 1**
Encountered an error due to the use of **order** as the name for the Order entity, which is a reserved keyword in MariaDB.

**Solution**
Added the following configuration property: `spring.jpa.properties.hibernate.globally_quoted_identifiers=true`:  
This automatically inserts backticks around identifiers, resolving the conflict with the reserved keyword **order** in MariaDB.

**Issue 2**
Faced an error during SQL script execution before table auto-creation.

**Solution**
Set `spring.jpa.defer-datasource-initialization=true` to defer datasource initialization.
Set `sql.init.mode=always` to switch from using the embedded database to MariaDB.

## Future Implementations

- [x] Implement exception handling to enhance robustness.
- [x] Design and implement response models for the frontend.